### PR TITLE
publish module and schema type for using the component in convex-test

### DIFF
--- a/commonjs.json
+++ b/commonjs.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "../src/package.json"],
+  "exclude": ["src/**/*.test.*", "../src/package.json", "src/test.ts"],
   "compilerOptions": {
     "outDir": "./dist/commonjs",
     "types": ["node", "react"]

--- a/esm.json
+++ b/esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "../src/package.json"],
+  "exclude": ["src/**/*.test.*", "../src/package.json", "src/test.ts"],
   "compilerOptions": {
     "outDir": "./dist/esm"
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "default": "./dist/commonjs/client/index.js"
       }
     },
+    "./test": "./src/test.ts",
     "./react": {
       "import": {
         "@convex-dev/react-source": "./src/react/index.ts",

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,3 @@
+import schema from "./component/schema.js";
+const modules = import.meta.glob("./**/*.ts");
+export default { schema, modules };


### PR DESCRIPTION
<!-- Describe your PR here. -->

Publish a `test.ts` file (like in [workflow](https://github.com/get-convex/workflow/blob/main/src/test.ts)) so this component can be registered with `convex-test`.

Not familiar with publishing packages so I have not really tested this but just wanted to put it on the convex team radar since it seems like a simple change.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
