### PR TITLE
Genericize register signature in src/test.ts

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -9,10 +9,9 @@ const modules = import.meta.glob("./component/**/*.ts");
  * @param t - The test convex instance, e.g. from calling `convexTest`.
  * @param name - The name of the component, as registered in convex.config.ts.
  */
-export function register(
-  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
-  name: string = "rateLimiter",
-) {
+export function register<
+  Schema extends SchemaDefinition<GenericSchema, boolean>,
+>(t: TestConvex<Schema>, name: string = "rateLimiter") {
   t.registerComponent(name, schema, modules);
 }
 export default { register, schema, modules };


### PR DESCRIPTION
## Summary
Match `@convex-dev/agent`'s and `@convex-dev/workflow`'s generic `register` signature so callers can pass a `TestConvex` with a specifically-inferred schema:

```ts
// before
export function register(
  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
  name: string = "rateLimiter",
) { ... }

// after
export function register<
  Schema extends SchemaDefinition<GenericSchema, boolean>,
>(t: TestConvex<Schema>, name: string = "rateLimiter") { ... }
```

## Context
`TestConvex` is invariant in its schema parameter (it appears in both contravariant input positions like `t.query(...)` args and covariant return positions). That means a `TestConvex<SchemaDefinition<{ tableA: ..., tableB: ... }>>` returned by `convexTest(schema, modules)` with a real schema is not assignable to `TestConvex<SchemaDefinition<GenericSchema, boolean>>`, even though the value is structurally fine.

Downstream projects currently work around this with a cast at the call site:

```ts
rateLimiter.register(
  t as unknown as TestConvex<SchemaDefinition<GenericSchema, boolean>>,
);
```

`@convex-dev/agent` already moved to a generic register signature in get-convex/agent@e29f2bb, and `@convex-dev/workflow` followed in 0.3.12. This PR brings rate-limiter in line so the cast can be dropped. See get-convex/agent#262 for the downstream context.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 94 tests pass
- [x] `npm run lint` clean
- [x] No runtime change — only the parameter type narrows from a fixed wide type to a generic constrained by the same wide type.